### PR TITLE
start fixing color rendering in wgpu

### DIFF
--- a/benser/src/css/color.rs
+++ b/benser/src/css/color.rs
@@ -10,8 +10,4 @@ impl Color {
     pub fn new(r: u8, g: u8, b: u8, a: u8) -> Self {
         Color { r, g, b, a }
     }
-
-    pub fn as_float(&self) -> [f32; 4] {
-        [self.r.into(), self.g.into(), self.b.into(), self.a.into()]
-    }
 }

--- a/paint/src/lib.rs
+++ b/paint/src/lib.rs
@@ -3,6 +3,7 @@ use benser::layout::{BoxType, LayoutBox, Rect};
 
 type DisplayList = Vec<DisplayCommand>;
 
+#[derive(Debug)]
 pub enum DisplayCommand {
     SolidColor(Color, Rect),
 }


### PR DESCRIPTION
relates to #2 

The colors in wgpu are messed up at the moment. This PR makes them slightly less messed up.

Sources

https://github.com/gfx-rs/wgpu/issues/2878
https://en.wikipedia.org/wiki/SRGB
https://github.com/three-rs/three/blob/07e47da5e0673aa9a16526719e16debd59040eec/src/color.rs#L39

https://sotrh.github.io/learn-wgpu/beginner/tutorial4-buffer/#color-correction
> Most monitors use a color space known as sRGB. Our surface is (most likely depending on what is returned from surface.get_preferred_format()) using an sRGB texture format. The sRGB format stores colors according to their relative brightness instead of their actual brightness. The reason for this is that our eyes don't perceive light linearly. We notice more differences in darker colors than we do in lighter colors.
> 
> You get the correct color using the following formula: srgb_color = ((rgb_color / 255 + 0.055) / 1.055) ^ 2.4. Doing this with an RGB value of (188, 0, 188) will give us (0.5028864580325687, 0.0, 0.5028864580325687). A little off from our (0.5, 0.0, 0.5). Instead of doing manual color conversion, you'll likely save a lot of time by using textures instead as they are stored as sRGB by default, so they don't suffer from the same color inaccuracies that vertex colors do. We'll cover textures in the next lesson.
```